### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: PHPUnit
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    tests:
+        strategy:
+            matrix:
+                php:
+                    - 7.3
+                    - 7.4
+                    - 8.0
+
+        name: PHP ${{ matrix.php }}
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  tools: composer:v2
+
+            - name: Install PHP Dependencies
+              run: composer install --no-interaction --no-progress
+
+            - name: Execute PHPUnit
+              run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -14,9 +16,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
It will now allow installations on environments with PHP 8.0 installed.

It also upgrades PHPUnit to its latest version and upgraded the phpunit.xml accordingly.

Finally, it setups GitHub Actions to run the test suite across the supported PHP versions.

P.S. Given that PHP 7.1 and 7.2 has reached [end of life](https://www.php.net/supported-versions.php) I dropped them and bumped the constraint to `^7.3`.